### PR TITLE
refactor: decouple otp code from google iam

### DIFF
--- a/common/error.go
+++ b/common/error.go
@@ -1,4 +1,4 @@
-package iam
+package common
 
 import "fmt"
 

--- a/common/util.go
+++ b/common/util.go
@@ -1,4 +1,4 @@
-package iam
+package common
 
 import (
 	"context"

--- a/google_iam/iam.go
+++ b/google_iam/iam.go
@@ -10,7 +10,7 @@ import (
 	"firebase.google.com/go/auth"
 	"github.com/google/uuid"
 
-	iam "github.com/ranesidd/iam"
+	common "github.com/ranesidd/iam/common"
 )
 
 var (
@@ -74,11 +74,11 @@ func (c *GoogleIAM) CreateAccount(ctx context.Context, account CreateAccountRequ
 		},
 	}
 
-	if !iam.IsEmpty(user.PhoneNumber) {
+	if !common.IsEmpty(user.PhoneNumber) {
 		newAccount.Account.Phone = &user.PhoneNumber
 	}
 
-	if !iam.IsEmpty(user.PhotoURL) {
+	if !common.IsEmpty(user.PhotoURL) {
 		newAccount.Account.PhotoURL = &user.PhotoURL
 	}
 
@@ -111,11 +111,11 @@ func (c *GoogleIAM) GetAccount(ctx context.Context, accountUID string) (*Account
 		Disabled:      &user.Disabled,
 	}
 
-	if !iam.IsEmpty(user.PhoneNumber) {
+	if !common.IsEmpty(user.PhoneNumber) {
 		account.Phone = &user.PhoneNumber
 	}
 
-	if !iam.IsEmpty(user.PhotoURL) {
+	if !common.IsEmpty(user.PhotoURL) {
 		account.PhotoURL = &user.PhotoURL
 	}
 
@@ -146,11 +146,11 @@ func (c *GoogleIAM) UpdateAccount(ctx context.Context, accountUID string, accoun
 		},
 	}
 
-	if !iam.IsEmpty(user.PhoneNumber) {
+	if !common.IsEmpty(user.PhoneNumber) {
 		updatedAccount.Account.Phone = &user.PhoneNumber
 	}
 
-	if !iam.IsEmpty(user.PhotoURL) {
+	if !common.IsEmpty(user.PhotoURL) {
 		updatedAccount.Account.PhotoURL = &user.PhotoURL
 	}
 
@@ -228,9 +228,9 @@ func (c *GoogleIAM) Initiate(ctx context.Context, email string) error {
 	}
 
 	if exists {
-		return iam.IAMError{
+		return common.IAMError{
 			Message: "Account already exists",
-			Code:    iam.AlreadyExists,
+			Code:    common.AlreadyExists,
 		}
 	}
 
@@ -279,11 +279,11 @@ func (c *GoogleIAM) SignIn(ctx context.Context, email, password string) (*SignIn
 
 	var response SignInResponse
 	url := fmt.Sprintf(signInLink, c.apiKey)
-	err = iam.HttpPost(
+	err = common.HttpPost(
 		ctx,
 		url,
 		map[string][]string{
-			"Content-Type": {string(iam.HTTPContentTypeAppJSON)},
+			"Content-Type": {string(common.HTTPContentTypeAppJSON)},
 		},
 		strings.NewReader(string(marshalledRequest)),
 		&response)

--- a/google_iam/setup.go
+++ b/google_iam/setup.go
@@ -2,7 +2,6 @@ package googleiam
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"os"
 
@@ -11,7 +10,6 @@ import (
 )
 
 type GoogleIAM struct {
-	db     *sql.DB
 	app    *firebase.App
 	apiKey string
 }
@@ -31,17 +29,6 @@ func New() (*GoogleIAM, error) {
 		app:    app,
 		apiKey: apiKey,
 	}, nil
-}
-
-func NewWithOTP(db *sql.DB) (*GoogleIAM, error) {
-	iamInstance, err := New()
-	if err != nil {
-		return nil, err
-	}
-
-	iamInstance.db = db
-
-	return iamInstance, nil
 }
 
 func initializeGoogleAdminSDK() (*firebase.App, error) {

--- a/google_iam/setup_test.go
+++ b/google_iam/setup_test.go
@@ -66,10 +66,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestNewWithOTP(t *testing.T) {
-
-}
-
 func setupTest(t *testing.T, env Env) func(t *testing.T, env Env) {
 
 	// Set keys to tmp_* if already set in env

--- a/google_iam/types.go
+++ b/google_iam/types.go
@@ -1,9 +1,5 @@
 package googleiam
 
-import (
-	"time"
-)
-
 type Account struct {
 	UUID          string  `json:"uuid,omitempty"`
 	DisplayName   string  `json:"display_name,omitempty"`
@@ -67,10 +63,4 @@ type SignInResponse struct {
 
 type SignOutRequest struct {
 	UUID string `json:"uuid"`
-}
-
-type OTP struct {
-	Email     string    `json:"email,omitempty"`
-	Code      string    `json:"code,omitempty"`
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
 }

--- a/init.go
+++ b/init.go
@@ -1,0 +1,42 @@
+package iam
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+
+	googleiam "github.com/ranesidd/iam/google_iam"
+)
+
+type IAM struct {
+	db        *sql.DB
+	googleIAM *googleiam.GoogleIAM
+}
+
+func New() (*IAM, error) {
+
+	iamInstance := &IAM{}
+
+	gcpFlag := os.Getenv("PROVIDER_GCP")
+	if len(gcpFlag) != 0 && strings.Contains(strings.ToLower(gcpFlag), "true") {
+		googleIAM, err := googleiam.New()
+		if err != nil {
+			return nil, err
+		}
+
+		iamInstance.googleIAM = googleIAM
+	}
+
+	return iamInstance, nil
+}
+
+func NewWithDatabase(db *sql.DB) (*IAM, error) {
+	iamInstance, err := New()
+	if err != nil {
+		return nil, err
+	}
+
+	iamInstance.db = db
+
+	return iamInstance, nil
+}

--- a/otp/types.go
+++ b/otp/types.go
@@ -1,0 +1,9 @@
+package otp
+
+import "time"
+
+type OTPPayload struct {
+	Email     string    `json:"email,omitempty"`
+	Code      string    `json:"code,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+}


### PR DESCRIPTION
Separated OTP code from google iam. OTP is now provider independent and can be used standalone as well.